### PR TITLE
Allow discovery of hx992s + potentially others, allow integration to start up after home assistant restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.idea/
+/.idea

--- a/custom_components/sonicare_bletb/coordinator.py
+++ b/custom_components/sonicare_bletb/coordinator.py
@@ -25,7 +25,7 @@ class SonicareBLETBCoordinator(DataUpdateCoordinator[None]):
         self._sonicare_ble = sonicare_ble
         sonicare_ble.register_callback(self._async_handle_update)
         sonicare_ble.register_disconnected_callback(self._async_handle_disconnect)
-        self.connected = False
+        self.connected = True
 
     @callback
     def _async_handle_update(self, state: SonicareBLETBState) -> None:

--- a/custom_components/sonicare_bletb/manifest.json
+++ b/custom_components/sonicare_bletb/manifest.json
@@ -4,9 +4,6 @@
   "version": "0.0.1",
   "bluetooth": [
     {
-      "manufacturer_id": 477
-    },
-    {
       "service_uuid": "477ea600-a260-11e4-ae37-0002a5d50001"
     },
     {

--- a/custom_components/sonicare_bletb/manifest.json
+++ b/custom_components/sonicare_bletb/manifest.json
@@ -5,6 +5,12 @@
   "bluetooth": [
     {
       "manufacturer_id": 477
+    },
+    {
+      "service_uuid": "477ea600-a260-11e4-ae37-0002a5d50001"
+    },
+    {
+      "local_name": "Philips Sonicare"
     }
   ],
   "codeowners": ["@GrumpyMeow"],

--- a/custom_components/sonicare_bletb/manifest.json
+++ b/custom_components/sonicare_bletb/manifest.json
@@ -13,5 +13,5 @@
   "documentation": "https://www.home-assistant.io/integrations/sonicare_bletb/",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["bluetooth-data-tools==0.3.1", "sonicare-bletb==0.0.8"]
+  "requirements": ["bluetooth-data-tools==0.4.0", "sonicare-bletb==0.0.8"]
 }

--- a/custom_components/sonicare_bletb/manifest.json
+++ b/custom_components/sonicare_bletb/manifest.json
@@ -4,6 +4,9 @@
   "version": "0.0.1",
   "bluetooth": [
     {
+      "manufacturer_id": 477
+    },
+    {
       "service_uuid": "477ea600-a260-11e4-ae37-0002a5d50001"
     },
     {

--- a/custom_components/sonicare_bletb/manifest.json
+++ b/custom_components/sonicare_bletb/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "sonicare_bletb",
   "name": "Sonicare BLE Toothbrush",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "bluetooth": [
     {
       "manufacturer_id": 477


### PR DESCRIPTION
1. Adding service_uuid and local_name options as discovery in the manifest.json should allow to find most if not all soniccare toothbrushes that are broadcasting. Previous my HX992s would not be discovered by the integration, it is now discovered. Others models should be tested.
2. bluetooth-data-tools must be updated to 0.4.0 for more recent version of home assistant
3. Add SonicareBLETBSensor to additionally inherit from RestoreEntity along with a native_state and assumed_state property. This should resolve the issue of the integration continuously attempting to "reload" and "rediscover" after a restart of home assistant. Previously after restart unless the toothbrush was actively broadcasting (which only happens during use and some short period after) the integration would be continuously in a reloading cycle. With these changes the integration will simply load with the restored sensor values
![image](https://github.com/GrumpyMeow/sonicare-ble-hacs/assets/12637936/4aaf0990-7ca3-4c61-b409-37c75fd3a7cd)
 